### PR TITLE
release/v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,8 @@ Simply pass a local directory that you wish to view the work for, this also work
 ```bash
 today work/very-important-business-app
 
-today work/api work/frontend
+today work/api work/frontend work/new-serivce # You've been very busy
+
+today --since 48h work/frontend # You missed standup yesterday
 ```
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ go install github.com/jdockerty/today@latest # or tag
 
 Or by downloading a pre-compiled binary on the [releases](https://github.com/jdockerty/today/releases) page.
 
-
 ## Usage
 
 Simply pass a local directory that you wish to view the work for, this also works over multiple directories, as work is not always confined to a single project.
@@ -22,8 +21,9 @@ Simply pass a local directory that you wish to view the work for, this also work
 ```bash
 today work/very-important-business-app
 
-today work/api work/frontend work/new-serivce # You've been very busy
+today work/api work/frontend work/new-important-serivce # You've been very busy
 
-today --since 48h work/frontend # You missed standup yesterday
+today --since 48h work/api # You missed standup yesterday
 ```
 
+Modifying the time range is done using the `--since` flag, valid time units for this conform to [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration). The main use case for this is to extend or reduce the number of hours you wish to search across, but you may get incredibly precise if you so desire.

--- a/today.go
+++ b/today.go
@@ -10,8 +10,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
-// Default to searching 12 hours of commits for each repository given.
-var defaultSince = 12 * time.Hour
+// Since is a flag used to control the amount of time to look back in a repository for commits.
+// The provided time units must be parseable via time.ParseDuration and it defaults to 12 hours.
+var since time.Duration
 
 // validatePaths is used to ensure that only directories that are tracked by git are passed into the application,
 // as these directories are used to track the work which was been done, via commit messages.
@@ -114,6 +115,7 @@ func getCommitMessages(dirToRepo map[string]*git.Repository, since time.Duration
 
 func main() {
 
+	flag.DurationVar(&since, "since", 12*time.Hour, "how far back to check for commits from now")
 	flag.Parse()
 
 	// Directories must be tracked by git so that we can read commit messages and use this
@@ -137,7 +139,7 @@ func main() {
 		dirToRepo[dirs[i]] = repos[i]
 	}
 
-	msgs, err := getCommitMessages(dirToRepo, defaultSince)
+	msgs, err := getCommitMessages(dirToRepo, since)
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
Add extra information to `README.md`

Convert the default `since` to a `time.Duration` specified by the user, this is far more flexible.
