### PR TITLE
feat/usage-and-graceful-exit-handling

### DIFF
--- a/today.go
+++ b/today.go
@@ -163,7 +163,7 @@ func main() {
 	err := validatePaths(flag.Args())
 	if err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(2)
 	}
 
 	dirs := flag.Args()

--- a/today.go
+++ b/today.go
@@ -131,16 +131,15 @@ func getCommitMessages(dirToRepo map[string]*git.Repository, short bool, since t
 
 
 func printUsage() {
-	fullPath, err := os.Executable()
 	var executableName string
-
+	fullPath, err := os.Executable()
 	if err != nil {
-		executableName = ""
+		executableName = "today"
 	} else {
 		executableName = filepath.Base(fullPath)
 	}
 
-	fmt.Fprintf(os.Stderr, "Usage: %s [options] git_directory_name...\n",executableName)
+        fmt.Fprintf(os.Stderr, "Usage: %s [options] git_directory...\n", executableName)
 	flag.PrintDefaults()
 }
 
@@ -153,7 +152,7 @@ func main() {
 	flag.Parse()
 	
 	if flag.NArg() == 0 {
-		fmt.Fprintf(os.Stderr, "Missing mandatory argument: git_directory_name\n")
+		fmt.Fprintln(os.Stderr, "Missing mandatory argument: git_directory")
 		printUsage()
 		os.Exit(1)
 	}

--- a/today.go
+++ b/today.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
-	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
 )
@@ -129,7 +129,6 @@ func getCommitMessages(dirToRepo map[string]*git.Repository, short bool, since t
 	return msgs, nil
 }
 
-
 func printUsage() {
 	var executableName string
 	fullPath, err := os.Executable()
@@ -139,7 +138,7 @@ func printUsage() {
 		executableName = filepath.Base(fullPath)
 	}
 
-        fmt.Fprintf(os.Stderr, "Usage: %s [options] git_directory...\n", executableName)
+	fmt.Fprintf(os.Stderr, "Usage: %s [options] git_directory...\n", executableName)
 	flag.PrintDefaults()
 }
 
@@ -150,7 +149,7 @@ func main() {
 	flag.BoolVar(&short, "short", false, "display the first line of commit messages only")
 	flag.DurationVar(&since, "since", 12*time.Hour, "how far back to check for commits from now")
 	flag.Parse()
-	
+
 	if flag.NArg() == 0 {
 		fmt.Fprintln(os.Stderr, "Missing mandatory argument: git_directory")
 		printUsage()

--- a/today.go
+++ b/today.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
 )
@@ -128,11 +129,34 @@ func getCommitMessages(dirToRepo map[string]*git.Repository, short bool, since t
 	return msgs, nil
 }
 
+
+func printUsage() {
+	fullPath, err := os.Executable()
+	var executableName string
+
+	if err != nil {
+		executableName = ""
+	} else {
+		executableName = filepath.Base(fullPath)
+	}
+
+	fmt.Fprintf(os.Stderr, "Usage: %s [options] git_directory_name...\n",executableName)
+	flag.PrintDefaults()
+}
+
 func main() {
+
+	flag.Usage = printUsage
 
 	flag.BoolVar(&short, "short", false, "display the first line of commit messages only")
 	flag.DurationVar(&since, "since", 12*time.Hour, "how far back to check for commits from now")
 	flag.Parse()
+	
+	if flag.NArg() == 0 {
+		fmt.Fprintf(os.Stderr, "Missing mandatory argument: git_directory_name\n")
+		printUsage()
+		os.Exit(1)
+	}
 
 	// Directories must be tracked by git so that we can read commit messages and use this
 	// as a guide on work done throughout a time period.


### PR DESCRIPTION
When I first downloaded the tool, I ran it without reading the documentation and just executed it without any command line args, The default behavior is to do nothing. I added a usage statement and sanity check to make sure that the user supplied at least one directory otherwise it prints out the usage info and an error message.

I also noticed the program has a return code of zero when it encounters an error reading a git repo and adding in a non-zero return code.