### PR TITLE
refactor: integration tests to CommitSuite

### DIFF
--- a/today_test.go
+++ b/today_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 // TODO: Cleanup the larger tests which use setupRepo func into `suite` tests.
@@ -29,6 +30,168 @@ const (
 	oneMinuteSince time.Duration = 1 * time.Minute
 	twoDaysSince   time.Duration = 48 * time.Hour
 )
+
+// Involves all tests which require reading/writing of a commit, this is requires the setup and teardown
+// of a directory which is tracked by git.
+type CommitSuite struct {
+	suite.Suite
+	Repo     *git.Repository // Repo to use within the test suite.
+	Worktree *git.Worktree
+}
+
+func setupRepo(url string, t *testing.T) (*git.Repository, error) {
+
+	r, err := git.PlainClone(t.TempDir(), false, &git.CloneOptions{
+		URL:               url,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// Setup before every test, whilst this might be a little inefficient for getting the repository before
+// every test, we do so to ensure that our commit history is completely fresh from previous test commits.
+func (suite *CommitSuite) SetupTest() {
+	r, err := setupRepo(thisRepo, suite.T())
+	if err != nil {
+		suite.FailNow("Unable to setup CommitSuite repo: %s\n", err)
+	}
+
+	suite.Repo = r
+
+	w, err := r.Worktree()
+	if err != nil {
+		suite.FailNow("Unable to setup CommitSuite worktree: %s\n", err)
+	}
+	suite.Worktree = w
+}
+
+func (suite *CommitSuite) TestFullContainsAuthor() {
+
+	assert := assert.New(suite.T())
+
+	w, err := suite.Repo.Worktree()
+	assert.Nil(err)
+
+	_, err = w.Commit("TEST", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, testSignature.Author.Name, true, oneMinuteSince)
+	assert.Nil(err)
+
+	assert.Contains(msgs, "today")
+	assert.GreaterOrEqual(2, len(msgs)) // Our 2 commits here and any others which are within 48 hours.
+
+}
+
+func (suite *CommitSuite) TestFullContainsAuthorHasNoCommits() {
+
+	assert := assert.New(suite.T())
+
+	_, err := suite.Worktree.Commit("TEST", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, "INVALID_COMMIT_AUTHOR", true, oneMinuteSince)
+	assert.Nil(err)
+
+	assert.Contains(msgs, "today")
+	assert.Equal(0, len(msgs["today"]))
+}
+
+func (suite *CommitSuite) TestNoResultsForZeroSinceValue() {
+
+	assert := assert.New(suite.T())
+
+	_, err := suite.Worktree.Commit("TEST", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, "", true, zeroTime)
+	assert.Nil(err)
+
+	assert.Equal(0, len(msgs["today"]))
+
+}
+
+func (suite *CommitSuite) TestResultsForMinimalSinceValue() {
+
+	assert := assert.New(suite.T())
+
+	_, err := suite.Worktree.Commit("TEST", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, "", true, oneMinuteSince)
+	assert.Nil(err)
+
+	assert.Contains(msgs, "today")
+	assert.Equal("TEST", msgs["today"][0]) // We know there is a single message here, as we made it for the test
+	assert.Equal(1, len(msgs))
+
+}
+
+func (suite *CommitSuite) TestResultsForLargerSinceValue() {
+
+	assert := assert.New(suite.T())
+
+	_, err := suite.Worktree.Commit("TEST", testSignature)
+	assert.Nil(err)
+
+	_, err = suite.Worktree.Commit("TEST2", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, "", true, twoDaysSince)
+	assert.Nil(err)
+
+	assert.Contains(msgs, "today")
+	assert.GreaterOrEqual(2, len(msgs)) // Our 2 commits here and any others which are within 48 hours.
+
+}
+
+func (suite *CommitSuite) TestShortCommitMessage() {
+
+	assert := assert.New(suite.T())
+
+	_, err := suite.Worktree.Commit("TEST\nNOT SEEN", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, "", true, oneMinuteSince)
+	assert.Nil(err)
+
+	assert.Equal(4, len(msgs["today"][0])) // Length of 'TEST' = 4
+}
+
+func (suite *CommitSuite) TestLongCommitMessage() {
+
+	assert := assert.New(suite.T())
+
+	_, err := suite.Worktree.Commit("TEST\nSEEN", testSignature)
+	assert.Nil(err)
+
+	m := make(map[string]*git.Repository, 1)
+	m["today"] = suite.Repo
+	msgs, err := getCommitMessages(m, "", false, oneMinuteSince)
+	assert.Nil(err)
+
+	assert.Equal("TEST\nSEEN", msgs["today"][0])
+}
+
+func TestCommitSuite(t *testing.T) {
+	suite.Run(t, new(CommitSuite))
+}
 
 func TestValidatePathsProducesErrorWithInvalidDir(t *testing.T) {
 	invalidPath := []string{"/does/not/exist"}
@@ -78,174 +241,4 @@ func TestDoesNotContainAuthor(t *testing.T) {
 
 	got := containsAuthor(testCommit, "John")
 	assert.False(t, got)
-}
-
-func TestFullContainsAuthor(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, testSignature.Author.Name, true, oneMinuteSince)
-	assert.Nil(err)
-
-	assert.Contains(msgs, "today")
-	assert.GreaterOrEqual(2, len(msgs)) // Our 2 commits here and any others which are within 48 hours.
-
-}
-func TestFullContainsAuthorHasNoCommits(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, "INVALID_COMMIT_AUTHOR", true, oneMinuteSince)
-	assert.Nil(err)
-
-	assert.Contains(msgs, "today")
-	assert.Equal(0, len(msgs["today"]))
-
-}
-
-func TestNoResultsForZeroSinceValue(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, "", true, zeroTime)
-	assert.Nil(err)
-
-	assert.Equal(0, len(msgs["today"]))
-
-}
-func TestResultsForMinimalSinceValue(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, "", true, oneMinuteSince)
-	assert.Nil(err)
-
-	assert.Contains(msgs, "today")
-	assert.Equal("TEST", msgs["today"][0]) // We know there is a single message here, as we made it for the test
-	assert.Equal(1, len(msgs))
-
-}
-
-func TestResultsForLargerSinceValue(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST", testSignature)
-	assert.Nil(err)
-	_, err = w.Commit("TEST2", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, "", true, twoDaysSince)
-	assert.Nil(err)
-
-	assert.Contains(msgs, "today")
-	assert.GreaterOrEqual(2, len(msgs)) // Our 2 commits here and any others which are within 48 hours.
-
-}
-
-func TestShortCommitMessage(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST\nNOT SEEN", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, "", true, oneMinuteSince)
-	assert.Nil(err)
-
-	assert.Equal(4, len(msgs["today"][0])) // Length of 'TEST' = 4
-}
-
-func TestLongCommitMessage(t *testing.T) {
-
-	assert := assert.New(t)
-
-	r, err := setupRepo(thisRepo, t)
-	assert.Nil(err)
-
-	w, err := r.Worktree()
-	assert.Nil(err)
-
-	_, err = w.Commit("TEST\nSEEN", testSignature)
-	assert.Nil(err)
-
-	m := make(map[string]*git.Repository, 1)
-	m["today"] = r
-	msgs, err := getCommitMessages(m, "", false, oneMinuteSince)
-	assert.Nil(err)
-
-	assert.Equal("TEST\nSEEN", msgs["today"][0])
-}
-
-func setupRepo(url string, t *testing.T) (*git.Repository, error) {
-
-	r, err := git.PlainClone(t.TempDir(), false, &git.CloneOptions{
-		URL:               url,
-		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return r, nil
 }


### PR DESCRIPTION
These longer tests now run the setup before each test to ensure that they have a fresh cloned repository each time

This is also simpler to keep track of the tests, as it allows room for some growth. All tests which are related to making a `commit` in a repository to test functionality can utilise the `CommitSuite` struct.